### PR TITLE
Log broken URLs too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/subscriptionlistcleanup.js
+++ b/subscriptionlistcleanup.js
@@ -73,6 +73,7 @@ function cleanup (err, opmltext) {
 									reallysimple.readFeed (theNode.xmlUrl, function (err, theFeed) {
 										var secs = ", " + utils.secondsSince (whenstart) + " secs"
 										if (err) {
+											console.log (theNode.xmlUrl + " failed");
 											}
 										else {
 											console.log (theFeed.title + secs);


### PR DESCRIPTION
For confirmation that the script processed everything in OPML, it's helpful if it logs broken URLs, paralleling logging info retrieved from the working URLs.

This PR also adds .gitignore to prevent future contributors from accidentally committing node_modules.